### PR TITLE
Add threadCPUTime measurements based on threadCPUTime#

### DIFF
--- a/src/Streamly/Metrics/Channel/Common.hs
+++ b/src/Streamly/Metrics/Channel/Common.hs
@@ -1,0 +1,48 @@
+module Streamly.Metrics.Channel.Common
+    (
+      aggregateListBy
+    , printKV
+    )
+where
+
+import Control.Monad.IO.Class (liftIO, MonadIO)
+import Data.Bifunctor (second)
+import Data.Maybe (fromJust, isJust)
+import Streamly.Internal.Data.Time.Units (AbsTime)
+import Streamly.Metrics.Type (showList, Indexable)
+import Streamly.Prelude (SerialT, MonadAsync)
+
+import qualified Streamly.Data.Fold as Fold
+import qualified Streamly.Internal.Data.Fold as Fold
+import qualified Streamly.Internal.Data.Stream.IsStream as Stream
+
+import Prelude hiding (showList)
+
+-------------------------------------------------------------------------------
+-- Event processing
+-------------------------------------------------------------------------------
+
+aggregateListBy :: (MonadAsync m, Ord k, Fractional a) =>
+    Double -> Int -> SerialT m (AbsTime, (k, [a])) -> SerialT m (k, [a])
+aggregateListBy timeout batchsize stream =
+    fmap (second fromJust)
+        $ Stream.filter (isJust . snd)
+        $ Stream.classifySessionsBy
+            0.1 False (return . (> 1000)) timeout f stream
+
+    where
+
+    scale Nothing _ = Nothing
+    scale (Just xs) count = Just $ map (/ count) xs
+
+    f =
+        Fold.teeWithFst
+            scale
+            (Fold.take batchsize (Fold.foldl1' (zipWith (+))))
+            (Fold.lmap (const 1) Fold.sum)
+
+printKV :: (MonadIO m, Show k, Show a, Indexable a) =>
+    SerialT m (k, [a]) -> m b
+printKV stream =
+    let f (k, xs) = liftIO $ putStrLn $ show k ++ ":\n" ++ showList xs
+     in Stream.mapM_ f stream >> error "printChannel: Metrics channel closed"

--- a/src/Streamly/Metrics/Channel/Unbounded.hs
+++ b/src/Streamly/Metrics/Channel/Unbounded.hs
@@ -1,4 +1,4 @@
-module Streamly.Metrics.Channel
+module Streamly.Metrics.Channel.Unbounded
     (
       Channel
     , newChannel
@@ -10,42 +10,34 @@ module Streamly.Metrics.Channel
     )
 where
 
-import Control.Concurrent (forkIO, ThreadId)
-import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TBQueue
-    (TBQueue, newTBQueue, readTBQueue, writeTBQueue)
+import Control.Concurrent (forkIO, ThreadId, yield)
+import Control.Concurrent.Chan
 import Control.Monad.IO.Class (liftIO, MonadIO)
-import Data.Bifunctor (second)
 import Data.Function ((&))
-import Data.Maybe (fromJust, isJust)
 import Streamly.Internal.Data.Time.Clock (getTime, Clock (Monotonic))
 import Streamly.Internal.Data.Time.Units (AbsTime)
 import Streamly.Metrics.Perf.Type (PerfMetrics(..))
 import Streamly.Metrics.Perf (benchWith)
-import Streamly.Metrics.Type (showList, Indexable)
+import Streamly.Metrics.Type (Indexable)
 import Streamly.Prelude (SerialT, MonadAsync)
 
-import qualified Streamly.Data.Fold as Fold
-import qualified Streamly.Internal.Data.Fold as Fold
 import qualified Streamly.Internal.Data.Stream.IsStream as Stream
 
 import Prelude hiding (showList)
+import Streamly.Metrics.Channel.Common
 
 -------------------------------------------------------------------------------
 -- Event processing
 -------------------------------------------------------------------------------
 
--- XXX Use streamly SVar instead so that we do not need STM and we can use just
--- one channel type.
-
--- | A metrics channel.
-newtype Channel a = Channel (TBQueue (AbsTime, ([Char], [a])))
+-- | An unbounded metrics channel. TBChannel should be preferred but this can
+-- be used when STM cannot be used e.g. if TBChannel would create nested STM
+-- transactions.
+newtype Channel a = Channel (Chan (AbsTime, ([Char], [a])))
 
 -- | Create a new metrics channel.
 newChannel :: IO (Channel a)
-newChannel = atomically $ do
-    tbq <- newTBQueue 1
-    return $ Channel tbq
+newChannel = Channel <$> newChan
 
 -- | Send a list of metrics to a metrics channel.
 -- @send channel description metrics@
@@ -53,37 +45,11 @@ send :: MonadIO m => Channel a -> String -> [a] -> m ()
 send (Channel chan) desc metrics = do
     -- XXX should use asyncClock
     now <- liftIO $ getTime Monotonic
-    liftIO $ atomically $ writeTBQueue chan (now, (desc, metrics))
+    liftIO $ writeChan chan (now, (desc, metrics))
+    liftIO yield
 
-fromChan :: MonadAsync m => TBQueue a -> SerialT m a
-fromChan = Stream.repeatM . (liftIO . atomically . readTBQueue)
-
-aggregateListBy :: (MonadAsync m, Ord k, Fractional a) =>
-    Double -> Int -> SerialT m (AbsTime, (k, [a])) -> SerialT m (k, [a])
-aggregateListBy timeout batchsize stream =
-    fmap (second fromJust)
-        $ Stream.filter (isJust . snd)
-        $ Stream.classifySessionsBy
-            0.1 False (return . (> 1000)) timeout f stream
-
-    where
-
-    scale Nothing _ = Nothing
-    scale (Just xs) count = Just $ map (/ count) xs
-
-    f =
-        Fold.teeWithFst
-            scale
-            (Fold.take batchsize (Fold.foldl1' (zipWith (+))))
-            (Fold.lmap (const 1) Fold.sum)
-
-printKV :: (MonadIO m, Show k, Show a, Indexable a) =>
-    SerialT m (k, [a]) -> m b
-printKV stream =
-    let f (k, xs) = liftIO $ putStrLn $ show k ++ ":\n" ++ showList xs
-     in Stream.mapM_ f stream >> error "printChannel: Metrics channel closed"
-
--- XXX Print actual batch size and also scale the results per event.
+fromChan :: MonadAsync m => Chan a -> SerialT m a
+fromChan = Stream.repeatM . (liftIO . readChan)
 
 -- | Forever print the metrics on a channel to the console periodically after
 -- aggregating the metrics collected till now.

--- a/src/Streamly/Metrics/Perf.hs
+++ b/src/Streamly/Metrics/Perf.hs
@@ -3,8 +3,6 @@ module Streamly.Metrics.Perf
       PerfMetrics(..)
     , benchWith
     , bench
-    , benchOnWith
-    , benchOn
     , preRun
     , postRun
     )
@@ -14,7 +12,6 @@ import Control.Monad (unless)
 import Data.Maybe (catMaybes)
 import GHC.Stats (getRTSStats, getRTSStatsEnabled, RTSStats(..))
 import Streamly.Internal.Data.Time.Units (NanoSecond64, fromAbsTime)
-import Streamly.Metrics.Channel (Channel, send)
 import Streamly.Metrics.Measure (measureWith)
 import Streamly.Metrics.Perf.Type (PerfMetrics(..), checkMonotony)
 import Streamly.Metrics.Perf.RUsage (getRuMetrics, pattern RUsageSelf)
@@ -121,16 +118,3 @@ benchWith = measureWith preRun postRun
 -- | Like 'benchWith' but benchmark an action instead.
 bench :: IO a -> IO (a, [PerfMetrics])
 bench action = benchWith (const action) ()
-
--- | Benchmark a function application and the send the results to the specified
--- metrics channel.
-benchOnWith :: Channel PerfMetrics -> String -> (a -> IO b) -> a -> IO b
-benchOnWith chan desc f arg = do
-    (r, xs) <- benchWith f arg
-    send chan desc (Count 1 : xs)
-    return r
-
--- | Like 'benchOnWith' but benchmark an action instead of function
--- application.
-benchOn :: Channel PerfMetrics -> String -> IO b -> IO b
-benchOn chan desc f = benchOnWith chan desc (const f) ()

--- a/streamly-metrics.cabal
+++ b/streamly-metrics.cabal
@@ -127,6 +127,8 @@ library
      , Streamly.Metrics.Perf.Type
      , Streamly.Metrics.Perf.RUsage
      , Streamly.Metrics.Channel
+     , Streamly.Metrics.Channel.Unbounded
+     , Streamly.Metrics.Channel.Common
      , Streamly.Metrics.Measure
      , Streamly.Metrics.File
      , Streamly.Metrics.Console

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,7 @@
 import Control.Concurrent(threadDelay)
-import Streamly.Metrics.Channel (Channel, newChannel, forkChannelPrinter)
+import Streamly.Metrics.Channel
+    (Channel, newChannel, forkChannelPrinter, benchOnWith)
 -- import Streamly.Metrics.Channel (printChannel)
-import Streamly.Metrics.Perf (benchOnWith)
 import Streamly.Metrics.Perf.Type (PerfMetrics)
 
 import qualified Streamly.Prelude as Stream


### PR DESCRIPTION
This change depends on a change in GHC RTS adding `threadCPUTime#` primitive to measure the cpu time spent by individual Haskell threads.